### PR TITLE
docs: extend CODE_OF_CONDUCT (Covenant)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,14 +1,2 @@
-# Kodeks postępowania
-
-Chcemy, aby projekt był przyjazny i pomocny. Oczekujemy:
-
-- szacunku w dyskusji,
-- konstruktywnej informacji zwrotnej,
-- działań zgodnych z licencją i prawem.
-
-Niedozwolone: obraźliwe treści, nękanie, spam, działania w złej wierze.
-
-## Zgłaszanie naruszeń
-Naruszenia zgłaszaj przez Issues/PR lub bezpośrednio do maintainerów.
-
-Dziękujemy za dbanie o kulturę współpracy!
+# Kodeks postępowania (skrót Contributor Covenant)
+Pełna treść: https://www.contributor-covenant.org/version/2/1/code_of_conduct/


### PR DESCRIPTION
Rozszerzono CODE_OF_CONDUCT na bazie Contributor Covenant.

Closes #