### PR TITLE
docs: enable GitHub Pages

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,0 +1,9 @@
+# Witamy w projekcie Passport Commit Test 🚀
+
+To jest strona projektu hostowana na **GitHub Pages**.  
+Repozytorium: [applowiec/passport-commit-test](https://github.com/applowiec/passport-commit-test)
+
+## 📖 Dokumentacja
+- [RELEASE.md](RELEASE.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [SECURITY.md](SECURITY.md)


### PR DESCRIPTION
Dodano stronę startową dla GitHub Pages w pliku index.md.